### PR TITLE
[Training Plans] Calendar now shows actual run distances

### DIFF
--- a/src/components/Training/AllTrainingPlans.jsx
+++ b/src/components/Training/AllTrainingPlans.jsx
@@ -13,6 +13,8 @@ import {
   ViewTrainingPlanRoute,
 } from '../../constants/routes'
 
+import formatMileage from '../../formatters/formatMileage.js'
+
 const AllTrainingPlans = () => {
   const [state, dispatch] = useContext(StateContext)
   const history = useHistory()
@@ -176,8 +178,12 @@ const AllTrainingPlans = () => {
                         }).toLocaleString()}
                       </div>
                       <div className='text-center'>{training.weeks.length}</div>
-                      <div className=''>{training.actualDistance} mi</div>
-                      <div className=''>{training.plannedDistance} mi</div>
+                      <div className=''>
+                        {formatMileage(training.actualDistance)} mi
+                      </div>
+                      <div className=''>
+                        {formatMileage(training.plannedDistance)} mi
+                      </div>
                       <div className='relative'>
                         <button
                           className='text-xs px-2 py-1 border border-gray-700 rounded bg-offwhite-100 hover:bg-offwhite-200 transition cursor-pointer'

--- a/src/components/Training/CalendarDate.jsx
+++ b/src/components/Training/CalendarDate.jsx
@@ -43,6 +43,7 @@ const CalendarDate = ({
   }
 
   let showPlannedInput = true
+
   if (isPastDate || (date.actualDistance > 0 && isCurrentDate)) {
     showPlannedInput = false
   }
@@ -239,7 +240,7 @@ const CalendarDate = ({
           )}
 
           {!showPlannedInput && (
-            <span className='block text-center h-6 w-full cursor-default'>
+            <span className='block text-center font-semibold h-6 w-full cursor-default'>
               {formatMileage(date.actualDistance)}
             </span>
           )}

--- a/src/components/Training/CalendarDate.jsx
+++ b/src/components/Training/CalendarDate.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { DateTime } from 'luxon'
 
+import formatMileage from '../../formatters/formatMileage.js'
+
 const CalendarDate = ({
   date,
   className,
@@ -31,7 +33,19 @@ const CalendarDate = ({
     maskClasses += ' hidden'
   }
 
-  const dt = DateTime.fromISO(date.dateISO, { zone: 'utc' })
+  const dt = DateTime.fromISO(date.dateISO, { zone: 'utc' }).startOf('day')
+  const now = DateTime.now().startOf('day')
+
+  let isPastDate = dt < now
+  const isCurrentDate = now.toISODate() === dt.toISODate()
+  if (isCurrentDate) {
+    isPastDate = false
+  }
+
+  let showPlannedInput = true
+  if (isPastDate || (date.actualDistance > 0 && isCurrentDate)) {
+    showPlannedInput = false
+  }
 
   // This list has to be in this file in order for Tailwind to generate the class names correctly
   const categoryClassName = {
@@ -208,19 +222,27 @@ const CalendarDate = ({
           {dt.toFormat('MM/dd')}
         </div>
         <div className='w-1/2 mx-auto py-1 border-b border-gray-500'>
-          <input
-            type='number'
-            min='0'
-            step='1'
-            className='text-center resize-none h-full w-full bg-transparent outline-none p-1 cursor-default'
-            value={plannedDistanceUI}
-            onFocus={(e) => {
-              e.target.select()
-            }}
-            onChange={(event) => {
-              onPlannedDistanceChange(event.target.value)
-            }}
-          />
+          {showPlannedInput && (
+            <input
+              type='number'
+              min='0'
+              step='1'
+              className='text-center resize-none h-6 w-full bg-transparent outline-none cursor-default'
+              value={plannedDistanceUI}
+              onFocus={(e) => {
+                e.target.select()
+              }}
+              onChange={(event) => {
+                onPlannedDistanceChange(event.target.value)
+              }}
+            />
+          )}
+
+          {!showPlannedInput && (
+            <span className='block text-center h-6 w-full cursor-default'>
+              {formatMileage(date.actualDistance)}
+            </span>
+          )}
         </div>
       </div>
       <div className='w-full h-32'>

--- a/src/components/Training/TrainingCalendar.jsx
+++ b/src/components/Training/TrainingCalendar.jsx
@@ -61,7 +61,7 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
     // If this is the current week, we need to investigate its dates for their distances
     if (weekISODates.indexOf(todayISODate) >= 0) {
       // For each date in this week, sum the actualDistances.
-      // If no actualDistance, use plannedDistance. If no plannedDistance, use 0.
+      // If no actualDistance, use plannedDistanceMeters. If no plannedDistanceMeters, use 0.
       for (let date of training.dates) {
         const dateDT = DateTime.fromISO(date.dateISO, { zone: 'utc' })
 
@@ -69,7 +69,7 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
           let dateDistance = date.actualDistance
 
           if (startOfTodayUTC < dateDT) {
-            dateDistance = date.plannedDistance
+            dateDistance = date.plannedDistanceMeters
           }
 
           weekDistance = addFloats(weekDistance, dateDistance)
@@ -81,7 +81,7 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
     else if (weekStartDT < startOfTodayUTC) {
       weekDistance = week.actualDistance // Past week
     } else {
-      weekDistance = week.plannedDistance // Future week
+      weekDistance = week.plannedDistanceMeters // Future week
     }
 
     weekDisplayDistances[weekIndex] = weekDistance
@@ -328,6 +328,7 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
           ...currentDate,
           actualDistance: copiedDate.actualDistance,
           plannedDistance: copiedDate.plannedDistance,
+          plannedDistanceMeters: copiedDate.plannedDistanceMeters,
           workout: copiedDate.workout,
           workoutCategory: copiedDate.workoutCategory,
         })

--- a/src/components/Training/TrainingCalendar.jsx
+++ b/src/components/Training/TrainingCalendar.jsx
@@ -490,7 +490,7 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
   return (
     <div className='w-full flex flex-col items-center justify-center text-sm lg:text-base z-0 mb-20'>
       {!disableSelection && (
-        <div className='flex fixed bottom-4 drop-shadow-xl z-30 mb-2 space-x-2 text-sm bg-offwhite-100 border rounded border-gray-900 px-4 py-3'>
+        <div className='flex fixed bottom-4 drop-shadow-xl z-30 mb-2 space-x-4 text-sm bg-offwhite-100 border rounded border-gray-900 px-4 py-3'>
           <button
             className={copyBtnClasses}
             disabled={!allowCopy}

--- a/src/components/Training/TrainingCalendar.jsx
+++ b/src/components/Training/TrainingCalendar.jsx
@@ -118,7 +118,7 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
   let columnWeekClasses =
     'w-16 grow-0 shrink-0 items-stretch flex flex-col items-center justify-center text-center px-2 py-1 border-r border-gray-900'
   let columnTotalClasses =
-    'w-24 grow-0 shrink-0 items-stretch flex flex-col items-center justify-center text-center px-2 py-1 border-r border-gray-900'
+    'w-24 grow-0 shrink-0 items-stretch flex flex-col items-center justify-center text-center px-2 py-1'
 
   let copyBtnClasses = 'border border-gray-900 rounded-lg px-2 py-1 transition'
   let pasteBtnClasses = 'border border-gray-900 rounded-lg px-2 py-1 transition'

--- a/src/components/Training/TrainingCalendar.jsx
+++ b/src/components/Training/TrainingCalendar.jsx
@@ -63,7 +63,9 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
       // For each date in this week, sum the actualDistances.
       // If no actualDistance, use plannedDistanceMeters. If no plannedDistanceMeters, use 0.
       for (let date of training.dates) {
-        const dateDT = DateTime.fromISO(date.dateISO, { zone: 'utc' })
+        const dateDT = DateTime.fromISO(date.dateISO, { zone: 'utc' }).startOf(
+          'day'
+        )
 
         if (weekStartDT <= dateDT && dateDT < weekEndDT) {
           let dateDistance = date.actualDistance

--- a/src/components/Training/ViewTrainingPlan.jsx
+++ b/src/components/Training/ViewTrainingPlan.jsx
@@ -22,7 +22,7 @@ const ViewTrainingPlan = () => {
   const location = useLocation()
   const history = useHistory()
   const id = location.pathname.split('/training/')[1]
-  const DEBUG = true
+  const DEBUG = false
   const DAYS_PER_WEEK = 7
 
   const training = state?.training?.byId[id]

--- a/src/components/Training/ViewTrainingPlan.jsx
+++ b/src/components/Training/ViewTrainingPlan.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEllipsisV, faStar, faSave } from '@fortawesome/free-solid-svg-icons'
 import { faStar as faStarOutline } from '@fortawesome/free-regular-svg-icons'
 import { useLocation, useHistory } from 'react-router-dom'
+
 import { StateContext } from '../../context/StateContext'
 import actions from '../../reducers/actions'
 import { APIv1 } from '../../api'
@@ -11,6 +12,7 @@ import { AllTrainingPlansRoute } from '../../constants/routes'
 
 import TrainingCalendar from './TrainingCalendar'
 import articlize from '../../utils/articlize.js'
+import formatMileage from '../../formatters/formatMileage.js'
 
 const ViewTrainingPlan = () => {
   const [state, dispatch] = useContext(StateContext)
@@ -20,21 +22,18 @@ const ViewTrainingPlan = () => {
   const location = useLocation()
   const history = useHistory()
   const id = location.pathname.split('/training/')[1]
-  const DEBUG = false
+  const DEBUG = true
   const DAYS_PER_WEEK = 7
 
   const training = state?.training?.byId[id]
 
   let planDesc = ''
   if (training != null) {
-    planDesc = `${articlize(training.plannedDistance, 'A', 'An')} ${
-      training.plannedDistance
-    }-mile, ${training.weeks.length}-week training plan from ${DateTime.fromISO(
-      training.startDate,
-      {
-        zone: 'utc',
-      }
-    ).toLocaleString()} through ${DateTime.fromISO(training.endDate, {
+    planDesc = `${articlize(training.weeks.length, 'A', 'An')} ${
+      training.weeks.length
+    }-week training plan from ${DateTime.fromISO(training.startDate, {
+      zone: 'utc',
+    }).toLocaleString()} through ${DateTime.fromISO(training.endDate, {
       zone: 'utc',
     }).toLocaleString()}`
   }
@@ -560,7 +559,7 @@ const ViewTrainingPlan = () => {
                   <>
                     <h2 className='mt-1'>Goal: {training.goal}</h2>
                     <h2 className='mt-1'>
-                      Mileage: {training.actualDistance} miles
+                      Mileage: {formatMileage(training.actualDistance)} miles
                     </h2>
                   </>
                 )}

--- a/src/formatters/formatPercentDiff.js
+++ b/src/formatters/formatPercentDiff.js
@@ -1,0 +1,16 @@
+// Given a number of meters, returns a number of the equivalent in miles.
+const formatPercentDiff = (diffString) => {
+  const number = Number(diffString)
+
+  if (Number.isNaN(number)) {
+    return diffString + '%'
+  }
+
+  if (number > 1000) {
+    return '1,000+%'
+  }
+
+  return `${Number(diffString).toFixed(2).toLocaleString()}%`
+}
+
+export default formatPercentDiff

--- a/src/utils/addFloats.js
+++ b/src/utils/addFloats.js
@@ -1,0 +1,17 @@
+// For two Numbers, add them together and return the value as a Number with at most two decimal places.
+const addFloats = (a, b) => {
+  if (
+    a == null ||
+    Number.isNaN(a) ||
+    typeof a !== 'number' ||
+    b == null ||
+    Number.isNaN(b) ||
+    typeof b !== 'number'
+  ) {
+    return NaN
+  }
+
+  return Math.round((a + b + Number.EPSILON) * 100) / 100
+}
+
+export default addFloats


### PR DESCRIPTION
Displays the actual distance the user has run on any given day with one or more runs.

- All existing plans are broken and must be deleted. New plans will work.
- Sums the distances for the week into a display-only value. This reflects any actual mileage and planned mileage per day (either one or the other)
- Displays the % change between weeks for this weekly distance total (even for future, planned distance only weeks)
- Combines mileage and % diff columns
- Creating a plan will calculate the actualDistance for any dates which have runs on them already