### PR TITLE
Hotfix for weekly display distance calculation

### DIFF
--- a/src/components/Training/TrainingCalendar.jsx
+++ b/src/components/Training/TrainingCalendar.jsx
@@ -72,8 +72,8 @@ const TrainingCalendar = ({ training, disableSelection, updatePlan }) => {
         if (weekStartDT <= dateDT && dateDT < weekEndDT) {
           let dateDistance = date.actualDistance
 
-          if (startOfTodayUTC < dateDT) {
-            dateDistance = date.plannedDistanceMeters
+          if (startOfTodayUTC <= dateDT) {
+            dateDistance = dateDistance || date.plannedDistanceMeters
           }
 
           weekDistance = addFloats(weekDistance, dateDistance)


### PR DESCRIPTION
Weekly display distance should prefer the current date's actualDistance to plannedDistance, but show the plannedDistance if no actualDistance is present.