### PR TITLE
Runs without pace or HR data are now formatted appropriately

### DIFF
--- a/src/components/Runs/RunTableRows.jsx
+++ b/src/components/Runs/RunTableRows.jsx
@@ -9,6 +9,7 @@ import { ViewRunRoute } from '../../constants/routes'
 import formatMileage from '../../formatters/formatMileage'
 import formatPace from '../../formatters/formatPace'
 import formatDuration from '../../formatters/formatDuration'
+import formatHeartRate from '../../formatters/formatHeartRate'
 import showWeekDivider from '../../utils/showWeekDivider'
 
 // Given an array of run activities, displays as table content
@@ -84,12 +85,12 @@ const RunTableRows = ({ runs, isLoading }) => {
           <div
             className={`${tableCellClasses} justify-self-end pl-2 sm:pl-4 md:pl-8 lg:pl-12`}
           >
-            {Math.round(run.averageHeartRate)}
+            {formatHeartRate(run.averageHeartRate)}
           </div>
           <div
             className={`${tableCellClasses} justify-self-end pl-2 sm:pl-4 md:pl-8 lg:pl-12 mr-4`}
           >
-            {run.maxHeartRate}
+            {formatHeartRate(run.maxHeartRate)}
           </div>
         </div>
 

--- a/src/components/Runs/ViewRun.jsx
+++ b/src/components/Runs/ViewRun.jsx
@@ -14,6 +14,7 @@ import { APIv1 } from '../../api'
 import formatMileage from '../../formatters/formatMileage'
 import formatPace from '../../formatters/formatPace'
 import formatDuration from '../../formatters/formatDuration'
+import formatHeartRate from '../../formatters/formatHeartRate'
 
 // Components
 import Checkbox from '../Forms/Checkbox'
@@ -287,28 +288,31 @@ const ViewRun = () => {
 
       {!state.runs.isFetching && (
         <section className='w-screen-xs flex flex-col items-start space-y-6 '>
-          <div className='w-full sm:w-auto flex justify-between items-center p-4 border border-gray-900 bg-offwhite-25 text-xl'>
-            <div className='flex flex-col items-center mr-4'>
+          <div className='w-full sm:w-auto flex justify-between items-center space-x-4 p-4 border border-gray-900 bg-offwhite-25 text-xl'>
+            <div className='flex flex-col items-center'>
               <div>{formatMileage(run.distance)}</div>
               <div className='text-base text-gray-600'>miles</div>
             </div>
 
-            <div className='flex flex-col items-center mr-4'>
+            <div className='flex flex-col items-center'>
               <div>{formatDuration(run.time)}</div>
               <div className='text-base text-gray-600'>time</div>
             </div>
 
-            <div className='flex flex-col items-center mr-4'>
+            <div className='flex flex-col items-center'>
               <div>{formatPace(run.averageSpeed)}</div>
               <div className='text-base text-gray-600'>pace</div>
             </div>
 
-            <div className='flex flex-col items-center'>
-              <div>
-                {Math.round(run.averageHeartRate)} / {run.maxHeartRate}
+            {run.hasHeartRate && (
+              <div className='flex flex-col items-center'>
+                <div>
+                  {formatHeartRate(run.averageHeartRate)} /{' '}
+                  {formatHeartRate(run.maxHeartRate)}
+                </div>
+                <div className='text-base text-gray-600'>heart rate</div>
               </div>
-              <div className='text-base text-gray-600'>heart rate</div>
-            </div>
+            )}
           </div>
 
           <div className='w-full max-w-screen-sm'>

--- a/src/formatters/formatDuration.js
+++ b/src/formatters/formatDuration.js
@@ -1,7 +1,7 @@
 import { Duration } from 'luxon'
 
 // Given a number of seconds, returns a string representing the duration of a run.
-const formatTime = (timeInSeconds) => {
+const formatDuration = (timeInSeconds) => {
   const duration = Duration.fromMillis(timeInSeconds * 1000)
 
   if (duration.as('hours') >= 1) {
@@ -11,4 +11,4 @@ const formatTime = (timeInSeconds) => {
   }
 }
 
-export default formatTime
+export default formatDuration

--- a/src/formatters/formatHeartRate.js
+++ b/src/formatters/formatHeartRate.js
@@ -1,0 +1,10 @@
+// Given a number of seconds, returns a string representing the duration of a run.
+const formatHeartRate = (heartRate) => {
+  if (heartRate == null || Number.isNaN(heartRate) || heartRate === 0) {
+    return '–'
+  }
+
+  return Math.round(heartRate)
+}
+
+export default formatHeartRate

--- a/src/formatters/formatPace.js
+++ b/src/formatters/formatPace.js
@@ -9,6 +9,14 @@ import {
 
 // Convert meters per second into minutes per mile, as a string to display to humans.
 const formatPace = (speedInMetersPerSecond) => {
+  if (
+    speedInMetersPerSecond == null ||
+    Number.isNaN(speedInMetersPerSecond) ||
+    speedInMetersPerSecond === 0
+  ) {
+    return '–'
+  }
+
   // Solve for x, given speed:
   //
   // 26.8224 min/mi       x min/mi             26.8224 min/mi


### PR DESCRIPTION
https://trello.com/c/6rcEkB3o/51-bug-runs-show-nan-hr-field-and-000-mi-pace-values-as-if-missing-data

Fixes simple UI bug for edge case runs.