### PR TITLE
Fixed bug where AllRuns table was showing duplicate runs briefly

### DIFF
--- a/src/components/Runs/AllRuns.jsx
+++ b/src/components/Runs/AllRuns.jsx
@@ -30,17 +30,16 @@ const AllRuns = () => {
       })
   }, [])
 
-  if (state == null || state.runs === null || state.runs.byId === null) {
-    return null
-  }
-
   return (
     <div className='AllRuns w-full pb-4 space-y-4 overflow-auto w-full'>
       <h1 className='mx-4 text-2xl'>All Runs</h1>
 
       <section className='overflow-scroll grid grid-cols-runs-page'>
         <RunTableHeaders />
-        <RunTableBody runs={state.runs.byId} isLoading={state.runs.isLoading} />
+        <RunTableBody
+          runs={state.runs.byId}
+          isLoading={state.runs.isFetching}
+        />
       </section>
     </div>
   )

--- a/src/components/Runs/RunTableBody.jsx
+++ b/src/components/Runs/RunTableBody.jsx
@@ -8,12 +8,12 @@ import showWeekDivider from '../../utils/showWeekDivider'
 
 // Given an array of run activities, displays as table content
 const RunTableBody = ({ runs, isLoading }) => {
-  if (runs == null || Object.keys(runs).length === 0) {
-    return null
+  if (isLoading) {
+    return <div className='w-full mx-4'>Loading...</div>
   }
 
-  if (isLoading) {
-    return <div className='w-full'>Loading...</div>
+  if (runs == null || Object.keys(runs).length === 0) {
+    return null
   }
 
   const sortedRuns = Object.values(runs).sort((a, b) => {

--- a/src/components/Runs/RunTableHeaders.jsx
+++ b/src/components/Runs/RunTableHeaders.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 const RunTableHeaders = () => {
   return (
     <div className='RunTableHeaders contents'>
-      <div className='whitespace-nowrap ml-4 pr-2 sm:pr-4 pb-1'>Date</div>
+      <div className='whitespace-nowrap ml-4 pb-1 col-span-2'>Date</div>
       <div className='whitespace-nowrap pr-2 sm:pr-4 pb-1'>Title</div>
       <div className='whitespace-nowrap justify-self-end pl-2 sm:pl-4 pb-1'>
         Miles

--- a/src/components/Runs/RunTableRow.jsx
+++ b/src/components/Runs/RunTableRow.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { DateTime } from 'luxon'
 import { Link } from 'react-router-dom'
 
 import { ViewRunRoute } from '../../constants/routes'
@@ -10,6 +9,8 @@ import { formatActualMileage } from '../../formatters/formatMileage'
 import formatPace from '../../formatters/formatPace'
 import formatDuration from '../../formatters/formatDuration'
 import formatHeartRate from '../../formatters/formatHeartRate'
+import formatWeekday from '../../formatters/formatWeekday'
+import formatDate from '../../formatters/formatDate'
 
 const RunTableRow = ({ run, showBottomBorder }) => {
   if (run == null) {
@@ -20,13 +21,11 @@ const RunTableRow = ({ run, showBottomBorder }) => {
 
   return (
     <div className='RunTableRow table-row contents'>
-      <div className={`${tableCellClasses} ml-4 pr-2 sm:pr-4 md:pr-8 lg:pr-12`}>
-        {DateTime.fromISO(run.startDate).toLocaleString({
-          weekday: 'long',
-          month: 'numeric',
-          day: 'numeric',
-          year: '2-digit',
-        })}
+      <div className={`${tableCellClasses} ml-4`}>
+        {formatWeekday(run.startDate)}
+      </div>
+      <div className={`${tableCellClasses} ml-2 pr-2 sm:pr-4 md:pr-8 lg:pr-12`}>
+        {formatDate(run.startDate)}
       </div>
       <div
         className={`${tableCellClasses} pr-2 sm:pr-4 md:pr-8 lg:pr-12 hover:underline`}
@@ -60,7 +59,7 @@ const RunTableRow = ({ run, showBottomBorder }) => {
       </div>
 
       {showBottomBorder && (
-        <div className='table-row col-span-7 pt-1 mb-1 mx-4 border-b border-eggplant-700' />
+        <div className='table-row col-span-8 pt-1 mb-1 mx-4 border-b border-eggplant-700' />
       )}
     </div>
   )

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -56,7 +56,10 @@ export const AuthContextProvider = (props) => {
   }, [])
 
   return (
-    <AuthContext.Provider value={[auth, authDispatch]}>
+    <AuthContext.Provider
+      value={[auth, authDispatch]}
+      displayName='Auth Context'
+    >
       {props.children}
     </AuthContext.Provider>
   )

--- a/src/context/StateContext.jsx
+++ b/src/context/StateContext.jsx
@@ -9,7 +9,10 @@ export const StateContextProvider = (props) => {
   const [state, dispatch] = useReducer(stateReducer, initialState)
 
   return (
-    <StateContext.Provider value={[state, dispatch]}>
+    <StateContext.Provider
+      value={[state, dispatch]}
+      displayName='State Context'
+    >
       {props.children}
     </StateContext.Provider>
   )

--- a/src/formatters/formatDate.js
+++ b/src/formatters/formatDate.js
@@ -1,0 +1,18 @@
+import { DateTime } from 'luxon'
+
+// Given a date string, returns a string representing the date in locally common numeric format.
+const formatDate = (date) => {
+  const dt = DateTime.fromISO(date)
+
+  if (!dt.isValid) {
+    return '–'
+  }
+
+  return dt.toLocaleString({
+    month: 'numeric',
+    day: 'numeric',
+    year: '2-digit',
+  })
+}
+
+export default formatDate

--- a/src/formatters/formatWeekday.js
+++ b/src/formatters/formatWeekday.js
@@ -1,0 +1,14 @@
+import { DateTime } from 'luxon'
+
+// Given a date string, returns a string representing the weekday as a 3-char abbreviation.
+const formatWeekday = (date) => {
+  const dt = DateTime.fromISO(date)
+
+  if (!dt.isValid) {
+    return '–'
+  }
+
+  return dt.toLocaleString({ weekday: 'long' }).substr(0, 3)
+}
+
+export default formatWeekday

--- a/src/reducers/stateReducer.js
+++ b/src/reducers/stateReducer.js
@@ -7,6 +7,8 @@ const stateReducer = (state, action) => {
         ...state,
         runs: {
           ...state.runs,
+          byId: state.runs.byId,
+          error: null,
           isFetching: true,
         },
       }
@@ -45,22 +47,18 @@ const stateReducer = (state, action) => {
     }
 
     case actions.GET_RUN__SUCCESS: {
-      const newRuns = {}
+      // Deep copy the map of the current state's run objects.
+      const newRunsById = JSON.parse(JSON.stringify(state.runs.byId))
 
-      // Copy the map of the current state's run objects.
-      for (let runId of Object.keys(state.runs)) {
-        newRuns[runId] = action.run
-      }
-
-      // Always overwrite this run object in the cloned map
-      newRuns[action.run._id] = action.run
+      // Overwrite the newly fetched run object in the new map
+      newRunsById[action.run._id] = action.run
 
       return {
         ...state,
         runs: {
           ...state.runs,
           isFetching: false,
-          byId: newRuns,
+          byId: newRunsById,
           error: null,
         },
       }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,7 +35,7 @@ module.exports = {
         248: '62rem', // screen-lg, minus 1rem each side for padding
       },
       gridTemplateColumns: {
-        'runs-page': 'repeat(7, minmax(auto, max-content))',
+        'runs-page': 'repeat(8, minmax(auto, max-content))',
         'plans-page': 'repeat(8, minmax(auto, max-content))',
       },
       colors: {


### PR DESCRIPTION
- ViewRun successful GET /run action will no longer overwrite the state.runs.byId state values
- Fixed the "Loading...." UI so it actually shows up while table is loading
- Minor UI change to date string display (e.g. "Wed 1/25/23" instead of "Wednesday, 1/25/23") and split into two columns (weekday and numeric date string)