### PR TITLE
Deleting runs will remove mileage from training plans and dailystats objects

### DIFF
--- a/src/components/Training/CreateTrainingPlan.jsx
+++ b/src/components/Training/CreateTrainingPlan.jsx
@@ -80,7 +80,7 @@ const CreateTrainingPlan = () => {
       .then((response) => {
         dispatch({
           type: actions.CREATE_TRAINING_PLAN__SUCCESS,
-          plan: response.data,
+          plan: response.data.plan,
         })
 
         history.push(AllTrainingPlansRoute)

--- a/src/components/UI/Button.jsx
+++ b/src/components/UI/Button.jsx
@@ -32,4 +32,10 @@ Button.propTypes = {
   children: PropTypes.node,
 }
 
+Button.defaultProps = {
+  onClick: () => {
+    return null
+  },
+}
+
 export default Button

--- a/src/components/User/AccountPage.jsx
+++ b/src/components/User/AccountPage.jsx
@@ -18,7 +18,7 @@ const AccountPage = () => {
       <Gear gear={auth.user.gear} />
 
       <StravaAccount
-        userId={auth?.user?.id}
+        userId={auth?.user?._id}
         hasStravaAccount={hasStravaAccount}
       />
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -34,7 +34,7 @@ export const AuthContextProvider = (props) => {
       })
 
       // Go get the full user information
-      APIv1.get(`/users/${user.id}`)
+      APIv1.get(`/users/${user._id}`)
         .then((response) => {
           // Then save the user info to auth state
           authDispatch({


### PR DESCRIPTION
- Tests to cover run deletion
- DailyStats will be removed if the only run for the day is deleted
- Plan actualDistance fields (plan, week, date) will be updated to reflect accurate distances
- User object as req.user will use `user._id` instead of an (anomalously named?) `id` field. Front end references are updated as well
- Fixes training plan creation bug