### PR TITLE
Card 88: Allow user to click actual distance number and open that run's page

### DIFF
--- a/src/components/Training/Calendar/ActualDistance.jsx
+++ b/src/components/Training/Calendar/ActualDistance.jsx
@@ -13,7 +13,7 @@ const ActualDistance = ({ isoDate, distance, runIds }) => {
 
   if (distance > 0) {
     return (
-      <span className='h-6 cursor-pointer hover:text-semibold hover:bg-eggplant-600 transition'>
+      <span className='h-6 cursor-pointer hover:underline'>
         <a
           target='_blank'
           rel='noopener noreferrer'

--- a/src/components/Training/Calendar/ActualDistance.jsx
+++ b/src/components/Training/Calendar/ActualDistance.jsx
@@ -1,37 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useHistory } from 'react-router-dom'
 import { AllRunsRoute, ViewRunRoute } from '../../../constants/routes'
 import { formatActualMileage } from '../../../formatters/formatMileage'
 
 const ActualDistance = ({ isoDate, distance, runIds }) => {
-  const history = useHistory()
-
-  const handleClick = (isoDate, runIds) => {
-    if (runIds == null || runIds.length === 0) {
-      return
-    }
-
-    // Go to run's page if only one run today. Otherwise, go to AllRuns page with a filter param.
-    let url
-    if (runIds.length === 1) {
-      url = ViewRunRoute.replace(':runId', runIds[0])
-    } else {
-      url = `${AllRunsRoute}?date=${isoDate}`
-    }
-
-    history.push(url)
+  // Go to run's page if only one run today. Otherwise, go to AllRuns page with a filter param.
+  const url = new URL(window.location)
+  let route = ViewRunRoute.replace(':runId', runIds[0])
+  if (runIds.length > 1) {
+    route = `${AllRunsRoute}?date=${isoDate}`
   }
 
   if (distance > 0) {
     return (
-      <span
-        className='h-6 cursor-pointer hover:text-semibold hover:bg-eggplant-600 transition'
-        onClick={() => {
-          handleClick(isoDate, runIds)
-        }}
-      >
-        {formatActualMileage(distance)}
+      <span className='h-6 cursor-pointer hover:text-semibold hover:bg-eggplant-600 transition'>
+        <a
+          target='_blank'
+          rel='noopener noreferrer'
+          href={`${url.origin}${route}`}
+        >
+          {formatActualMileage(distance)}
+        </a>
       </span>
     )
   } else {

--- a/src/components/Training/Calendar/ActualDistance.jsx
+++ b/src/components/Training/Calendar/ActualDistance.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useHistory } from 'react-router-dom'
+import { AllRunsRoute, ViewRunRoute } from '../../../constants/routes'
+import { formatActualMileage } from '../../../formatters/formatMileage'
+
+const ActualDistance = ({ isoDate, distance, runIds }) => {
+  const history = useHistory()
+
+  const handleClick = (isoDate, runIds) => {
+    if (runIds == null || runIds.length === 0) {
+      return
+    }
+
+    // Go to run's page if only one run today. Otherwise, go to AllRuns page with a filter param.
+    let url
+    if (runIds.length === 1) {
+      url = ViewRunRoute.replace(':runId', runIds[0])
+    } else {
+      url = `${AllRunsRoute}?date=${isoDate}`
+    }
+
+    history.push(url)
+  }
+
+  if (distance > 0) {
+    return (
+      <span
+        className='h-6 cursor-pointer hover:text-semibold hover:bg-eggplant-600 transition'
+        onClick={() => {
+          handleClick(isoDate, runIds)
+        }}
+      >
+        {formatActualMileage(distance)}
+      </span>
+    )
+  } else {
+    return <span className='h-6'>{formatActualMileage(distance)}</span>
+  }
+}
+
+ActualDistance.propTypes = {
+  isoDate: PropTypes.string.isRequired,
+  distance: PropTypes.number,
+  runIds: PropTypes.array,
+}
+
+export default ActualDistance

--- a/src/components/Training/Calendar/CalendarDate.jsx
+++ b/src/components/Training/Calendar/CalendarDate.jsx
@@ -148,6 +148,7 @@ const CalendarDate = ({
           plannedDistance={date.plannedDistance}
           actualDistance={date.actualDistance}
           showPlannedInput={showPlannedInput}
+          runIds={date.runIds}
         />
       </div>
 
@@ -200,6 +201,7 @@ CalendarDate.propTypes = {
     plannedDistance: PropTypes.number, // sometimes null, usually a number though
     workout: PropTypes.string,
     workoutCategory: PropTypes.number,
+    runIds: PropTypes.array,
   }).isRequired,
   onDateEdit: PropTypes.func.isRequired,
   onDateClick: PropTypes.func.isRequired,

--- a/src/components/Training/Calendar/CalendarDate.jsx
+++ b/src/components/Training/Calendar/CalendarDate.jsx
@@ -6,10 +6,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons'
 
 import WorkoutTextInput from './WorkoutTextInput'
-import PlannedDistanceInput from './PlannedDistanceInput'
 import CategoryOptionsMenu from './CategoryOptionsMenu'
-
-import { formatActualMileage } from '../../../formatters/formatMileage.js'
+import DateDistance from './DateDistance'
 
 const CalendarDate = ({
   date,
@@ -144,20 +142,13 @@ const CalendarDate = ({
           })}
         </div>
 
-        <div className='w-32 px-2 py-1 text-right cursor-default'>
-          {showPlannedInput ? (
-            <PlannedDistanceInput
-              distance={date.plannedDistance}
-              onChange={(value) =>
-                onDateEdit('plannedDistance', value, dt.toISODate())
-              }
-            />
-          ) : (
-            <span className='h-6 cursor-default'>
-              {formatActualMileage(date.actualDistance)}
-            </span>
-          )}
-        </div>
+        <DateDistance
+          isoDate={dt.toISODate()}
+          onDateEdit={onDateEdit}
+          plannedDistance={date.plannedDistance}
+          actualDistance={date.actualDistance}
+          showPlannedInput={showPlannedInput}
+        />
       </div>
 
       <div className='w-full relative' ref={containerRef}>

--- a/src/components/Training/Calendar/DateDistance.jsx
+++ b/src/components/Training/Calendar/DateDistance.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { useHistory } from 'react-router-dom'
+import { AllRunsRoute, ViewRunRoute } from '../../../constants/routes'
 import PlannedDistanceInput from './PlannedDistanceInput'
-import { formatActualMileage } from '../../../formatters/formatMileage.js'
+import { formatActualMileage } from '../../../formatters/formatMileage'
 
 const DateDistance = ({
   showPlannedInput,
@@ -9,7 +11,29 @@ const DateDistance = ({
   onDateEdit,
   plannedDistance,
   actualDistance,
+  runIds,
 }) => {
+  const history = useHistory()
+
+  const onActualDistanceClick = (isoDate, runIds) => {
+    console.log(isoDate)
+    console.log(runIds)
+
+    if (runIds == null || runIds.length === 0) {
+      return
+    }
+
+    // Go to run's page if only one run today. Otherwise, go to AllRuns page with a filter param.
+    let url
+    if (runIds.length === 1) {
+      url = ViewRunRoute.replace(':runId', runIds[0])
+    } else {
+      url = `${AllRunsRoute}?date=${isoDate}`
+    }
+
+    history.push(url)
+  }
+
   return (
     <div className='w-32 px-2 py-1 text-right cursor-default'>
       {showPlannedInput ? (
@@ -18,7 +42,12 @@ const DateDistance = ({
           onChange={(value) => onDateEdit('plannedDistance', value, isoDate)}
         />
       ) : (
-        <span className='h-6 cursor-default'>
+        <span
+          className='h-6 cursor-pointer hover:text-semibold hover:bg-eggplant-600 transition'
+          onClick={() => {
+            onActualDistanceClick(isoDate, runIds)
+          }}
+        >
           {formatActualMileage(actualDistance)}
         </span>
       )}
@@ -32,6 +61,7 @@ DateDistance.propTypes = {
   onDateEdit: PropTypes.func,
   plannedDistance: PropTypes.number,
   actualDistance: PropTypes.number,
+  runIds: PropTypes.array,
 }
 
 export default DateDistance

--- a/src/components/Training/Calendar/DateDistance.jsx
+++ b/src/components/Training/Calendar/DateDistance.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PlannedDistanceInput from './PlannedDistanceInput'
+import { formatActualMileage } from '../../../formatters/formatMileage.js'
+
+const DateDistance = ({
+  showPlannedInput,
+  isoDate,
+  onDateEdit,
+  plannedDistance,
+  actualDistance,
+}) => {
+  return (
+    <div className='w-32 px-2 py-1 text-right cursor-default'>
+      {showPlannedInput ? (
+        <PlannedDistanceInput
+          distance={plannedDistance}
+          onChange={(value) => onDateEdit('plannedDistance', value, isoDate)}
+        />
+      ) : (
+        <span className='h-6 cursor-default'>
+          {formatActualMileage(actualDistance)}
+        </span>
+      )}
+    </div>
+  )
+}
+
+DateDistance.propTypes = {
+  showPlannedInput: PropTypes.bool.isRequired,
+  isoDate: PropTypes.string.isRequired,
+  onDateEdit: PropTypes.func,
+  plannedDistance: PropTypes.number,
+  actualDistance: PropTypes.number,
+}
+
+export default DateDistance

--- a/src/components/Training/Calendar/DateDistance.jsx
+++ b/src/components/Training/Calendar/DateDistance.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useHistory } from 'react-router-dom'
-import { AllRunsRoute, ViewRunRoute } from '../../../constants/routes'
 import PlannedDistanceInput from './PlannedDistanceInput'
-import { formatActualMileage } from '../../../formatters/formatMileage'
+import ActualDistance from './ActualDistance'
 
 const DateDistance = ({
   showPlannedInput,
@@ -13,27 +11,6 @@ const DateDistance = ({
   actualDistance,
   runIds,
 }) => {
-  const history = useHistory()
-
-  const onActualDistanceClick = (isoDate, runIds) => {
-    console.log(isoDate)
-    console.log(runIds)
-
-    if (runIds == null || runIds.length === 0) {
-      return
-    }
-
-    // Go to run's page if only one run today. Otherwise, go to AllRuns page with a filter param.
-    let url
-    if (runIds.length === 1) {
-      url = ViewRunRoute.replace(':runId', runIds[0])
-    } else {
-      url = `${AllRunsRoute}?date=${isoDate}`
-    }
-
-    history.push(url)
-  }
-
   return (
     <div className='w-32 px-2 py-1 text-right cursor-default'>
       {showPlannedInput ? (
@@ -42,14 +19,11 @@ const DateDistance = ({
           onChange={(value) => onDateEdit('plannedDistance', value, isoDate)}
         />
       ) : (
-        <span
-          className='h-6 cursor-pointer hover:text-semibold hover:bg-eggplant-600 transition'
-          onClick={() => {
-            onActualDistanceClick(isoDate, runIds)
-          }}
-        >
-          {formatActualMileage(actualDistance)}
-        </span>
+        <ActualDistance
+          distance={actualDistance}
+          runIds={runIds}
+          isoDate={isoDate}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
- Adds support for plan.date.runIds array
- If a date has an actualDistance value, it will allow the user to hover and click on that amount.
- Clicking a date with exactly one run opens a new window with that run's data in a RunPage component
- If there are multiple runs for that date, the AllRuns page is opened with a query parameter for a date filter
- This PR does not include the work to display filtered results on the AllRuns page.