### PR TITLE
Remove reverse-geocode package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.3",
-    "react-toastify": "^10.0.4",
-    "reverse-geocode": "^1.3.3"
+    "react-toastify": "^10.0.4"
   },
   "scripts": {
     "dev": "vite",

--- a/src/components/Runs/ViewRun.jsx
+++ b/src/components/Runs/ViewRun.jsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect, useContext } from 'react'
+import { useState, useEffect, useContext } from 'react'
 
 import { toast } from 'react-toastify'
 
 import { useParams, useNavigate } from 'react-router-dom'
 import { DateTime } from 'luxon'
-import reverse from 'reverse-geocode'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-solid-svg-icons'
@@ -217,26 +216,6 @@ const ViewRun = () => {
     return stravaTimezoneString.split(' ')[1]
   }
 
-  // Given some run data, returns a string to use as the subheader for this page.
-  const generateSubheader = (runStartTime, timezone, lat, lng) => {
-    const dateTime = DateTime.fromISO(runStartTime, {
-      zone: stravaTimezoneToTZ(timezone),
-    }).toLocaleString(DateTime.DATETIME_FULL)
-
-    // NB: This only works for locations in the US. It's gonna give terrible data otherwise.
-    const location = reverse.lookup(lat, lng, 'us')
-
-    if (
-      location == null ||
-      location.city == null ||
-      location.state_abbr == null
-    ) {
-      return dateTime
-    }
-
-    return `${dateTime} in ${location.city}, ${location.state_abbr}`
-  }
-
   const onResultsChange = (event) => {
     // TODO: Debounced API call to update the value of the results field
     setResultsText(event.target.value)
@@ -342,12 +321,9 @@ const ViewRun = () => {
         )}
 
         <p className='text-neutral-500'>
-          {generateSubheader(
-            run.startDate,
-            run.timezone,
-            run.startLatitude,
-            run.startLongitude
-          )}
+          {DateTime.fromISO(run.startDate, {
+            zone: stravaTimezoneToTZ(run.timezone),
+          }).toLocaleString(DateTime.DATETIME_FULL)}
         </p>
       </header>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,11 +2854,6 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-reverse-geocode@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/reverse-geocode/-/reverse-geocode-1.3.3.tgz#afc3d7efc7cc65c33f6c7c656a7623ff5921477a"
-  integrity sha512-xfFKCmCjLk/WyEtsyZycZwlRiV02alFIjWv/yoTamolLFtWwAGTfk15BhaLblXvMpf+nwrfalzH+3jxc7g+8gA==
-
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"


### PR DESCRIPTION
Remove the `reverse-geocode` package due to bundled size. 

Loading the RunPage `/runs/:id`
- Before: 431kb of JS
- After: 135kb of JS